### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "ISC",
   "dependencies": {
     "chalk": "4.0.0",
-    "jsdom": "16.2.2",
+    "jsdom": "16.3.0",
     "meow": "^6.0.0",
     "node-sass": "^4.13.1",
     "purgecss": "2.1.0",


### PR DESCRIPTION
I had an issue with a bunch of errors like this: 

```
TypeError: Cannot read property 'some' of undefined
                                                                                       
      at Object.exports.install (node_modules/whatwg-url/dist/URL.js:84:20)
```

https://github.com/facebook/jest/issues/10489#issuecomment-695817956 - shows that its an issue with jsdom 16.2.2. I tested by forcing the next newer version 16.3.0 which fixed the problem, so I propose that this dependency be updated.