### PR TITLE
Handle string and array of strings for unusedCssClasses

### DIFF
--- a/src/main/getUnusedClasses.ts
+++ b/src/main/getUnusedClasses.ts
@@ -11,7 +11,7 @@ export default class UnusedClasses {
 
     return this.mapClasses(list).then((r) => {
       return r.filter((c) => {
-        const [unusedCssClasses] = c;
+        const unusedCssClasses: string[] | string = c?.length ? c[0] : [];
         return unusedCssClasses && unusedCssClasses.length > 0
       });
     }) as Promise<[[string[], string]]>;


### PR DESCRIPTION
Fix: https://github.com/ivanblazevic/ngx-unused-css/issues/32

```
TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
    at Object.__read (/usr/local/lib/node_modules/ngx-unused-css/node_modules/tslib/tslib.js:169:50)
    at /usr/local/lib/node_modules/ngx-unused-css/dist/src/main/getUnusedClasses.js:17:34
    at Array.filter (<anonymous>)
    at /usr/local/lib/node_modules/ngx-unused-css/dist/src/main/getUnusedClasses.js:16:22
```